### PR TITLE
alternative to throwing an error when wait = false with no msg in queue

### DIFF
--- a/include/ipc/ipc-client.hpp
+++ b/include/ipc/ipc-client.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <string_view>
+#include <optional>
 #include <unistd.h>
 
 #include "ipc/common.hpp"
@@ -14,7 +15,7 @@
   bool send##RequestType(const RequestType &request, requestId_t &oRequestId, bool wait = true)
 
 #define DECLARE_RECEIVE_RESPONSE(ResponseType) \
-  ResponseType receive##ResponseType(bool wait = true)
+  std::optional<ResponseType> receive##ResponseType(bool wait = true)
 
 
 class IpcClient

--- a/include/ipc/ipc-server.hpp
+++ b/include/ipc/ipc-server.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <string_view>
+#include <optional>
 #include <unistd.h>
 
 #include "ipc/common.hpp"
@@ -14,7 +15,7 @@
   bool send##ResponseType(const ResponseType &response, pid_t receiverId, bool wait = true)
 
 #define DECLARE_RECEIVE_REQUEST(RequestType) \
-  RequestType receive##RequestType(requestId_t &oRequestId, pid_t &oSenderId, bool wait = true)
+  std::optional<RequestType> receive##RequestType(requestId_t &oRequestId, pid_t &oSenderId, bool wait = true)
 
 
 class IpcServer

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -95,23 +95,23 @@ bool sendMsg(
  * @param wait Wether to block/wait for message or return immedeatly if queue is empty.
  *
  * @throw IpcException When recieving a message fails.
- * @return The number of bytes of payload (everything except the id) read from the message queue.
+ * @return Wether a message was received when wait is false, otherwise always true.
  */
 template<typename T>
-ssize_t receiveMsg(
+bool receiveMsg(
   int msgQueueId,
   T &payload,
   msgKey_t msgKey,
   bool wait
 );
 
-#define DECLARE_MSG_TEMPLATES(T)                                                    \
-  template struct RequestMsg<T>;                                                    \
-  template struct ResponseMsg<T>;                                                   \
-  template bool sendMsg<RequestMsg<T>>(int, const RequestMsg<T> &, bool);           \
-  template bool sendMsg<ResponseMsg<T>>(int, const ResponseMsg<T> &, bool);         \
-  template ssize_t receiveMsg<RequestMsg<T>>(int, RequestMsg<T> &, long , bool);    \
-  template ssize_t receiveMsg<ResponseMsg<T>>(int, ResponseMsg<T> &, long , bool);  \
+#define DECLARE_MSG_TEMPLATES(T)                                                \
+  template struct RequestMsg<T>;                                                \
+  template struct ResponseMsg<T>;                                               \
+  template bool sendMsg<RequestMsg<T>>(int, const RequestMsg<T> &, bool);       \
+  template bool sendMsg<ResponseMsg<T>>(int, const ResponseMsg<T> &, bool);     \
+  template bool receiveMsg<RequestMsg<T>>(int, RequestMsg<T> &, long , bool);   \
+  template bool receiveMsg<ResponseMsg<T>>(int, ResponseMsg<T> &, long , bool); \
 
 
 

--- a/src/ipc-client.cpp
+++ b/src/ipc-client.cpp
@@ -28,14 +28,15 @@ namespace fs = std::filesystem;
     return util::sendMsg(mMsgQueueId, msg, wait);           \
   }
 
-#define FN_RECEIVE_RESPONSE(ResponseType, MsgTypeNr)        \
-  ResponseType IpcClient::receive##ResponseType(bool wait)  \
-  {                                                         \
-    util::ResponseMsg<ResponseType> msg;                    \
-    msgKey_t msgKey = util::makeMsgKey(MsgTypeNr, mPid);    \
-    util::receiveMsg(mMsgQueueId, msg, msgKey, wait);       \
-                                                            \
-    return msg.payload;                                     \
+#define FN_RECEIVE_RESPONSE(ResponseType, MsgTypeNr)                      \
+  std::optional<ResponseType> IpcClient::receive##ResponseType(bool wait) \
+  {                                                                       \
+    util::ResponseMsg<ResponseType> msg;                                  \
+    msgKey_t msgKey = util::makeMsgKey(MsgTypeNr, mPid);                  \
+    if (util::receiveMsg(mMsgQueueId, msg, msgKey, wait))                 \
+      return msg.payload;                                                 \
+    else                                                                  \
+      return {};                                                          \
   }
 
 

--- a/src/ipc-server.cpp
+++ b/src/ipc-server.cpp
@@ -23,16 +23,19 @@ namespace fs = std::filesystem;
   }
 
 #define FN_RECEIVE_REQUEST(RequestType, MsgTypeNr)              \
-  RequestType IpcServer::receive##RequestType(                  \
+  std::optional<RequestType> IpcServer::receive##RequestType(   \
     requestId_t &oRequestId, pid_t &oSenderId, bool wait)       \
   {                                                             \
     util::RequestMsg<RequestType> msg;                          \
     msgKey_t msgKey = util::makeMsgKey(MsgTypeNr);              \
-    util::receiveMsg(mMsgQueueId, msg, msgKey, wait);           \
-                                                                \
-    oRequestId = msg.requestId;                                 \
-    oSenderId = msg.senderId;                                   \
-    return msg.payload;                                         \
+    if (util::receiveMsg(mMsgQueueId, msg, msgKey, wait))       \
+    {                                                           \
+      oRequestId = msg.requestId;                               \
+      oSenderId = msg.senderId;                                 \
+      return msg.payload;                                       \
+    }                                                           \
+    else                                                        \
+      return {};                                                \
   }
 
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -67,7 +67,7 @@ bool sendMsg(int msgQueueId, const T &payload, bool wait)
 }
 
 template<typename T>
-ssize_t receiveMsg(int msgQueueId, T &payload, long msgType, bool wait)
+bool receiveMsg(int msgQueueId, T &payload, long msgType, bool wait)
 {
   ssize_t nrBytes = ::msgrcv(
     msgQueueId,
@@ -76,9 +76,14 @@ ssize_t receiveMsg(int msgQueueId, T &payload, long msgType, bool wait)
     wait ? 0 : IPC_NOWAIT
   );
   if (nrBytes == -1)
-    throw IpcException("msgrcv");
+  {
+    if (errno == ENOMSG)
+      return false;
 
-  return nrBytes;
+    throw IpcException("msgrcv");
+  }
+
+  return true;
 }
 
 DECLARE_MSG_TEMPLATES(NodeRequest);


### PR DESCRIPTION
will return normally but null-opt for std::option if no msg was found in queue