### PR TITLE
proposed fix for counter macro being reevaluated on each use

### DIFF
--- a/include/ipc/common.hpp
+++ b/include/ipc/common.hpp
@@ -14,7 +14,8 @@
   char fieldName[MAX_ARRAY_SIZE][MAX_STRING_SIZE] = {0}
 
 static const uint32_t _INITIAL_COUNTER_VALUE = __COUNTER__;
-#define GET_COUNTER (__COUNTER__ - _INITIAL_COUNTER_VALUE)
+#define MAKE_MSG_TYPE \
+  static const msgType_t msgType = (__COUNTER__ - _INITIAL_COUNTER_VALUE)
 
 using msgKey_t                = __syscall_slong_t;
 using msgType_t               = int32_t;

--- a/include/ipc/datastructs/information-datastructs.hpp
+++ b/include/ipc/datastructs/information-datastructs.hpp
@@ -3,16 +3,18 @@
 #include "ipc/common.hpp"
 
 
-#define MSG_TYPE_NODE_REQUEST GET_COUNTER
 struct NodeRequest
 {
+  MAKE_MSG_TYPE;
+
   primaryKey_t primaryKey;
   bool updates;
 };
 
-#define MSG_TYPE_NODE_ALIVE_UPDATE GET_COUNTER
 struct NodeAliveUpdate
 {
+  MAKE_MSG_TYPE;
+
   primaryKey_t primaryKey;
   bool alive;
   time_t aliveChangeTime;
@@ -20,23 +22,26 @@ struct NodeAliveUpdate
   pid_t pid;
 };
 
-#define MSG_TYPE_NODE_PUBLISHES_TO_UPDATE GET_COUNTER
 struct NodePublishesToUpdate
 {
+  MAKE_MSG_TYPE;
+
   primaryKey_t primaryKey;
   MAKE_ARRAY(primaryKey_t, publishesTo);
 };
 
-#define MSG_TYPE_NODE_SUBSCRIBES_TO_UPDATE GET_COUNTER
 struct NodeSubscribesToUpdate
 {
+  MAKE_MSG_TYPE;
+
   primaryKey_t primaryKey;
   MAKE_ARRAY(primaryKey_t, subscribesTo);
 };
 
-#define MSG_TYPE_NODE_SERVICES_UPDATE GET_COUNTER
 struct NodeServicesUpdate
 {
+  MAKE_MSG_TYPE;
+
   primaryKey_t primaryKey;
   struct Service
   {
@@ -45,16 +50,18 @@ struct NodeServicesUpdate
   } services[MAX_ARRAY_SIZE];
 };
 
-#define MSG_TYPE_NODE_CLIENTS_UPDATE GET_COUNTER
 struct NodeClientsUpdate
 {
+  MAKE_MSG_TYPE;
+
   primaryKey_t primaryKey;
   MAKE_ARRAY(primaryKey_t, clients);
 };
 
-#define MSG_TYPE_NODE_RESPONSE GET_COUNTER
 struct NodeResponse
 {
+  MAKE_MSG_TYPE;
+
   primaryKey_t primaryKey;
   MAKE_STRING(name);
   MAKE_STRING(pkgName);
@@ -70,32 +77,36 @@ struct NodeResponse
 };
 
 
-#define MSG_TYPE_TOPIC_REQUEST GET_COUNTER
 struct TopicRequest
 {
+  MAKE_MSG_TYPE;
+
   primaryKey_t primaryKey;
   double targetFrequency;
   bool updates;
   bool continuous;
 };
 
-#define MSG_TYPE_TOPIC_PUBLISHERS_UPDATE GET_COUNTER
 struct TopicPublishersUpdate
 {
+  MAKE_MSG_TYPE;
+
   primaryKey_t primaryKey;
   MAKE_ARRAY(primaryKey_t, publishers);
 };
 
-#define MSG_TYPE_TOPIC_SUBSCRIBERS_UPDATE GET_COUNTER
 struct TopicSubscribersUpdate
 {
+  MAKE_MSG_TYPE;
+
   primaryKey_t primaryKey;
   MAKE_ARRAY(primaryKey_t, subscribers);
 };
 
-#define MSG_TYPE_TOPIC_RESPONSE GET_COUNTER
 struct TopicResponse
 {
+  MAKE_MSG_TYPE;
+
   primaryKey_t primaryKey;
   MAKE_STRING(name);
   MAKE_STRING(type);
@@ -114,9 +125,10 @@ struct TopicDataStreamObject
 };
 
 
-#define MSG_TYPE_PROCESS_REQUEST GET_COUNTER
 struct ProcessRequest
 {
+  MAKE_MSG_TYPE;
+
   pid_t pid; // primaryKey
   bool updates;
   enum class ContinuousType
@@ -125,16 +137,18 @@ struct ProcessRequest
   } continuous;
 };
 
-#define MSG_TYPE_PROCESS_CHILDREN_UPDATE GET_COUNTER
 struct ProcessChildrenUpdate
 {
+  MAKE_MSG_TYPE;
+
   pid_t pid;
   MAKE_ARRAY(pid_t, children);
 };
 
-#define MSG_TYPE_PROCESS_RESPONSE GET_COUNTER
 struct ProcessResponse
 {
+  MAKE_MSG_TYPE;
+
   pid_t pid;
   MAKE_STRING(name);
   sharedMemoryLocation_t sharedMemoryLocation;

--- a/include/ipc/datastructs/misc-datastructs.hpp
+++ b/include/ipc/datastructs/misc-datastructs.hpp
@@ -2,30 +2,37 @@
 
 #include "ipc/common.hpp"
 
-#define MSG_TYPE_INIT_REQUEST GET_COUNTER
+
 struct InitRequest {
+  MAKE_MSG_TYPE;
+
   MAKE_STRING(ignoredTopic);
 };
 
-#define MSG_TYPE_INIT_RESPONSE GET_COUNTER
-struct InitResponse {};
+struct InitResponse {
+  MAKE_MSG_TYPE;
+};
 
-#define MSG_TYPE_UNSUBSCRIBE_REQUEST GET_COUNTER
 struct UnsubscribeRequest {
+  MAKE_MSG_TYPE;
+
   requestId_t id;
 };
 
-#define MSG_TYPE_UNSUBSCRIBE_RESPONSE GET_COUNTER
-struct UnsubscribeResponse {};
+struct UnsubscribeResponse {
+  MAKE_MSG_TYPE;
+};
 
-#define MSG_TYPE_MSG_REQUEST GET_COUNTER
 struct MsgRequest {
+  MAKE_MSG_TYPE;
+
   requestId_t id;
   primaryKey_t primaryKey;
   double targetFrequency;
 };
 
-#define MSG_TYPE_MSG_RESPONSE GET_COUNTER
 struct MsgResponse {
+  MAKE_MSG_TYPE;
+
   sharedMemoryLocation_t sharedMemPtr;
 };

--- a/include/ipc/datastructs/namespace-datastructs.hpp
+++ b/include/ipc/datastructs/namespace-datastructs.hpp
@@ -2,15 +2,18 @@
 
 #include "ipc/common.hpp"
 
-#define MSG_TYPE_NAMESPACE_REQUEST GET_COUNTER
+
 struct NamespaceRequest {
-    requestId_t id;
-    MAKE_STRING(path);
-    bool updates;
+  MAKE_MSG_TYPE;
+
+  requestId_t id;
+  MAKE_STRING(path);
+  bool updates;
 };
 
-#define MSG_TYPE_NAMESPACE_RESPONSE GET_COUNTER
 struct NamespaceResponse {
-    MAKE_STRING_ARRAY(children);
-    uint32_t nrOfChildren;
+  MAKE_MSG_TYPE;
+
+  MAKE_STRING_ARRAY(children);
+  uint32_t nrOfChildren;
 };

--- a/include/ipc/datastructs/search-datastructs.hpp
+++ b/include/ipc/datastructs/search-datastructs.hpp
@@ -2,8 +2,10 @@
 
 #include "ipc/common.hpp"
 
-#define MSG_TYPE_SEARCH_REQUEST GET_COUNTER
+
 struct SearchRequest {
+  MAKE_MSG_TYPE;
+
   enum Type: uint8_t {
     NODE,
     TOPIC
@@ -11,7 +13,8 @@ struct SearchRequest {
   primaryKey_t primaryKey;
 };
 
-#define MSG_TYPE_SEARCH_RESPONSE GET_COUNTER
 struct SearchResponse {
+  MAKE_MSG_TYPE;
+
   primaryKey_t primaryKey;
 };

--- a/src/ipc-client.cpp
+++ b/src/ipc-client.cpp
@@ -12,30 +12,30 @@ namespace fs = std::filesystem;
 #include "ipc/ipc-exceptions.hpp"
 #include "util.hpp"
 
-#define FN_SEND_REQUEST(RequestType, MsgTypeNr)             \
-  bool IpcClient::send##RequestType(                        \
-    const RequestType &request, requestId_t &oRequestId,    \
-    bool wait)                                              \
-  {                                                         \
-    oRequestId = ++mRequestIdCounter;                       \
-    util::RequestMsg<RequestType> msg{                      \
-      .key = util::makeMsgKey(MsgTypeNr),                   \
-      .requestId = oRequestId,                              \
-      .senderId = mPid,                                     \
-      .payload = request                                    \
-    };                                                      \
-                                                            \
-    return util::sendMsg(mMsgQueueId, msg, wait);           \
+#define FN_SEND_REQUEST(RequestType)                                  \
+  bool IpcClient::send##RequestType(                                  \
+    const RequestType &request, requestId_t &oRequestId,              \
+    bool wait)                                                        \
+  {                                                                   \
+    oRequestId = ++mRequestIdCounter;                                 \
+    util::RequestMsg<RequestType> msg{                                \
+      .key = util::makeMsgKey(RequestType::msgType),                  \
+      .requestId = oRequestId,                                        \
+      .senderId = mPid,                                               \
+      .payload = request                                              \
+    };                                                                \
+                                                                      \
+    return util::sendMsg(mMsgQueueId, msg, wait);                     \
   }
 
-#define FN_RECEIVE_RESPONSE(ResponseType, MsgTypeNr)        \
-  ResponseType IpcClient::receive##ResponseType(bool wait)  \
-  {                                                         \
-    util::ResponseMsg<ResponseType> msg;                    \
-    msgKey_t msgKey = util::makeMsgKey(MsgTypeNr, mPid);    \
-    util::receiveMsg(mMsgQueueId, msg, msgKey, wait);       \
-                                                            \
-    return msg.payload;                                     \
+#define FN_RECEIVE_RESPONSE(ResponseType)                             \
+  ResponseType IpcClient::receive##ResponseType(bool wait)            \
+  {                                                                   \
+    util::ResponseMsg<ResponseType> msg;                              \
+    msgKey_t msgKey = util::makeMsgKey(ResponseType::msgType, mPid);  \
+    util::receiveMsg(mMsgQueueId, msg, msgKey, wait);                 \
+                                                                      \
+    return msg.payload;                                               \
   }
 
 
@@ -47,34 +47,34 @@ IpcClient::IpcClient(int projectId)
 }
 
 
-FN_SEND_REQUEST(NodeRequest, MSG_TYPE_NODE_REQUEST);
-FN_RECEIVE_RESPONSE(NodeResponse, MSG_TYPE_NODE_RESPONSE);
-FN_RECEIVE_RESPONSE(NodeAliveUpdate, MSG_TYPE_NODE_ALIVE_UPDATE);
-FN_RECEIVE_RESPONSE(NodePublishesToUpdate, MSG_TYPE_NODE_PUBLISHES_TO_UPDATE);
-FN_RECEIVE_RESPONSE(NodeSubscribesToUpdate, MSG_TYPE_NODE_SUBSCRIBES_TO_UPDATE);
-FN_RECEIVE_RESPONSE(NodeServicesUpdate, MSG_TYPE_NODE_SERVICES_UPDATE);
-FN_RECEIVE_RESPONSE(NodeClientsUpdate, MSG_TYPE_NODE_CLIENTS_UPDATE);
+FN_SEND_REQUEST(NodeRequest);
+FN_RECEIVE_RESPONSE(NodeResponse);
+FN_RECEIVE_RESPONSE(NodeAliveUpdate);
+FN_RECEIVE_RESPONSE(NodePublishesToUpdate);
+FN_RECEIVE_RESPONSE(NodeSubscribesToUpdate);
+FN_RECEIVE_RESPONSE(NodeServicesUpdate);
+FN_RECEIVE_RESPONSE(NodeClientsUpdate);
 
-FN_SEND_REQUEST(TopicRequest, MSG_TYPE_TOPIC_REQUEST);
-FN_RECEIVE_RESPONSE(TopicResponse, MSG_TYPE_TOPIC_RESPONSE);
-FN_RECEIVE_RESPONSE(TopicPublishersUpdate, MSG_TYPE_TOPIC_PUBLISHERS_UPDATE);
-FN_RECEIVE_RESPONSE(TopicSubscribersUpdate, MSG_TYPE_TOPIC_SUBSCRIBERS_UPDATE);
+FN_SEND_REQUEST(TopicRequest);
+FN_RECEIVE_RESPONSE(TopicResponse);
+FN_RECEIVE_RESPONSE(TopicPublishersUpdate);
+FN_RECEIVE_RESPONSE(TopicSubscribersUpdate);
 
-FN_SEND_REQUEST(ProcessRequest, MSG_TYPE_PROCESS_REQUEST);
-FN_RECEIVE_RESPONSE(ProcessResponse, MSG_TYPE_PROCESS_RESPONSE);
-FN_RECEIVE_RESPONSE(ProcessChildrenUpdate, MSG_TYPE_PROCESS_CHILDREN_UPDATE);
+FN_SEND_REQUEST(ProcessRequest);
+FN_RECEIVE_RESPONSE(ProcessResponse);
+FN_RECEIVE_RESPONSE(ProcessChildrenUpdate);
 
-FN_SEND_REQUEST(NamespaceRequest, MSG_TYPE_NAMESPACE_REQUEST);
-FN_RECEIVE_RESPONSE(NamespaceResponse, MSG_TYPE_INIT_RESPONSE);
+FN_SEND_REQUEST(NamespaceRequest);
+FN_RECEIVE_RESPONSE(NamespaceResponse);
 
-FN_SEND_REQUEST(SearchRequest, MSG_TYPE_SEARCH_REQUEST);
-FN_RECEIVE_RESPONSE(SearchResponse, MSG_TYPE_SEARCH_RESPONSE);
+FN_SEND_REQUEST(SearchRequest);
+FN_RECEIVE_RESPONSE(SearchResponse);
 
-FN_SEND_REQUEST(InitRequest, MSG_TYPE_INIT_REQUEST);
-FN_RECEIVE_RESPONSE(InitResponse, MSG_TYPE_INIT_RESPONSE);
+FN_SEND_REQUEST(InitRequest);
+FN_RECEIVE_RESPONSE(InitResponse);
 
-FN_SEND_REQUEST(UnsubscribeRequest, MSG_TYPE_UNSUBSCRIBE_REQUEST);
-FN_RECEIVE_RESPONSE(UnsubscribeResponse, MSG_TYPE_UNSUBSCRIBE_RESPONSE);
+FN_SEND_REQUEST(UnsubscribeRequest);
+FN_RECEIVE_RESPONSE(UnsubscribeResponse);
 
-FN_SEND_REQUEST(MsgRequest, MSG_TYPE_MSG_REQUEST);
-FN_RECEIVE_RESPONSE(MsgResponse, MSG_TYPE_MSG_RESPONSE);
+FN_SEND_REQUEST(MsgRequest);
+FN_RECEIVE_RESPONSE(MsgResponse);

--- a/src/ipc-server.cpp
+++ b/src/ipc-server.cpp
@@ -10,29 +10,29 @@ namespace fs = std::filesystem;
 #include "ipc/ipc-server.hpp"
 #include "util.hpp"
 
-#define FN_SEND_RESPONSE(ResponseType, MsgTypeNr)               \
-  bool IpcServer::send##ResponseType(                           \
-    const ResponseType &response, pid_t receiverId, bool wait)  \
-  {                                                             \
-    util::ResponseMsg<ResponseType> msg{                        \
-      .key = util::makeMsgKey(MsgTypeNr, receiverId),           \
-      .payload = response                                       \
-    };                                                          \
-                                                                \
-    return util::sendMsg(mMsgQueueId, msg, wait);               \
+#define FN_SEND_RESPONSE(ResponseType)                            \
+  bool IpcServer::send##ResponseType(                             \
+    const ResponseType &response, pid_t receiverId, bool wait)    \
+  {                                                               \
+    util::ResponseMsg<ResponseType> msg{                          \
+      .key = util::makeMsgKey(ResponseType::msgType, receiverId), \
+      .payload = response                                         \
+    };                                                            \
+                                                                  \
+    return util::sendMsg(mMsgQueueId, msg, wait);                 \
   }
 
-#define FN_RECEIVE_REQUEST(RequestType, MsgTypeNr)              \
-  RequestType IpcServer::receive##RequestType(                  \
-    requestId_t &oRequestId, pid_t &oSenderId, bool wait)       \
-  {                                                             \
-    util::RequestMsg<RequestType> msg;                          \
-    msgKey_t msgKey = util::makeMsgKey(MsgTypeNr);              \
-    util::receiveMsg(mMsgQueueId, msg, msgKey, wait);           \
-                                                                \
-    oRequestId = msg.requestId;                                 \
-    oSenderId = msg.senderId;                                   \
-    return msg.payload;                                         \
+#define FN_RECEIVE_REQUEST(RequestType)                           \
+  RequestType IpcServer::receive##RequestType(                    \
+    requestId_t &oRequestId, pid_t &oSenderId, bool wait)         \
+  {                                                               \
+    util::RequestMsg<RequestType> msg;                            \
+    msgKey_t msgKey = util::makeMsgKey(RequestType::msgType);     \
+    util::receiveMsg(mMsgQueueId, msg, msgKey, wait);             \
+                                                                  \
+    oRequestId = msg.requestId;                                   \
+    oSenderId = msg.senderId;                                     \
+    return msg.payload;                                           \
   }
 
 
@@ -54,34 +54,34 @@ IpcServer::~IpcServer()
 }
 
 
-FN_RECEIVE_REQUEST(NodeRequest, MSG_TYPE_NODE_REQUEST);
-FN_SEND_RESPONSE(NodeResponse, MSG_TYPE_NODE_RESPONSE);
-FN_SEND_RESPONSE(NodeAliveUpdate, MSG_TYPE_NODE_ALIVE_UPDATE);
-FN_SEND_RESPONSE(NodePublishesToUpdate, MSG_TYPE_NODE_PUBLISHES_TO_UPDATE);
-FN_SEND_RESPONSE(NodeSubscribesToUpdate, MSG_TYPE_NODE_SUBSCRIBES_TO_UPDATE);
-FN_SEND_RESPONSE(NodeServicesUpdate, MSG_TYPE_NODE_SERVICES_UPDATE);
-FN_SEND_RESPONSE(NodeClientsUpdate, MSG_TYPE_NODE_CLIENTS_UPDATE);
+FN_RECEIVE_REQUEST(NodeRequest);
+FN_SEND_RESPONSE(NodeResponse);
+FN_SEND_RESPONSE(NodeAliveUpdate);
+FN_SEND_RESPONSE(NodePublishesToUpdate);
+FN_SEND_RESPONSE(NodeSubscribesToUpdate);
+FN_SEND_RESPONSE(NodeServicesUpdate);
+FN_SEND_RESPONSE(NodeClientsUpdate);
 
-FN_RECEIVE_REQUEST(TopicRequest, MSG_TYPE_TOPIC_REQUEST);
-FN_SEND_RESPONSE(TopicResponse, MSG_TYPE_TOPIC_RESPONSE);
-FN_SEND_RESPONSE(TopicPublishersUpdate, MSG_TYPE_TOPIC_PUBLISHERS_UPDATE);
-FN_SEND_RESPONSE(TopicSubscribersUpdate, MSG_TYPE_TOPIC_SUBSCRIBERS_UPDATE);
+FN_RECEIVE_REQUEST(TopicRequest);
+FN_SEND_RESPONSE(TopicResponse);
+FN_SEND_RESPONSE(TopicPublishersUpdate);
+FN_SEND_RESPONSE(TopicSubscribersUpdate);
 
-FN_RECEIVE_REQUEST(ProcessRequest, MSG_TYPE_PROCESS_REQUEST);
-FN_SEND_RESPONSE(ProcessResponse, MSG_TYPE_PROCESS_RESPONSE);
-FN_SEND_RESPONSE(ProcessChildrenUpdate, MSG_TYPE_PROCESS_CHILDREN_UPDATE);
+FN_RECEIVE_REQUEST(ProcessRequest);
+FN_SEND_RESPONSE(ProcessResponse);
+FN_SEND_RESPONSE(ProcessChildrenUpdate);
 
-FN_RECEIVE_REQUEST(NamespaceRequest, MSG_TYPE_NAMESPACE_REQUEST);
-FN_SEND_RESPONSE(NamespaceResponse, MSG_TYPE_NAMESPACE_RESPONSE);
+FN_RECEIVE_REQUEST(NamespaceRequest);
+FN_SEND_RESPONSE(NamespaceResponse);
 
-FN_RECEIVE_REQUEST(SearchRequest, MSG_TYPE_SEARCH_REQUEST);
-FN_SEND_RESPONSE(SearchResponse, MSG_TYPE_SEARCH_RESPONSE);
+FN_RECEIVE_REQUEST(SearchRequest);
+FN_SEND_RESPONSE(SearchResponse);
 
-FN_RECEIVE_REQUEST(InitRequest, MSG_TYPE_INIT_REQUEST);
-FN_SEND_RESPONSE(InitResponse, MSG_TYPE_INIT_RESPONSE);
+FN_RECEIVE_REQUEST(InitRequest);
+FN_SEND_RESPONSE(InitResponse);
 
-FN_RECEIVE_REQUEST(UnsubscribeRequest, MSG_TYPE_UNSUBSCRIBE_REQUEST);
-FN_SEND_RESPONSE(UnsubscribeResponse, MSG_TYPE_UNSUBSCRIBE_RESPONSE);
+FN_RECEIVE_REQUEST(UnsubscribeRequest);
+FN_SEND_RESPONSE(UnsubscribeResponse);
 
-FN_RECEIVE_REQUEST(MsgRequest, MSG_TYPE_MSG_REQUEST);
-FN_SEND_RESPONSE(MsgResponse, MSG_TYPE_MSG_RESPONSE);
+FN_RECEIVE_REQUEST(MsgRequest);
+FN_SEND_RESPONSE(MsgResponse);


### PR DESCRIPTION
# problem
consider the following
```c++
#include <iostream>
#define A __COUTNER__

int main() {
  std::cout << A << '\n' << A << '\n';
}
```
Based on our current assumptions for the `MSG_TYPE_…` macros this should produce
```
0
0
```
when in reality it produces
```c++
0
1
```
since not the value of the macro but the value of the macro, which is __COUNTER__, is substituted.

# solution
Replacing the macros with `const static msgType_t msgType` fields would solve this and bring the added benefit of simplifying the `FN_…` convenience macros as the msgType field is directly associated with the data type (without being an actual field).

# consideration
Since the `MSG_TYPE_…` macros would only get used once this shouldn't actually matter and they definetly carry less runtime overhead. Still - there could be a situation we are not thinking about.